### PR TITLE
fix: Build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "example/dist/index.d.ts",
   "scripts": {
     "dev": "preact watch",
-    "build:widget": "microbundle build --alias react=preact/compat --jsx react-jsx",
+    "build:widget": "microbundle build --alias react=preact/compat",
     "build:lib": "microbundle build -i src/component.tsx",
     "lint": "eslint '{src,tests}/**/*.{ts,tsx}'",
     "test": "jest"

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { h, JSX } from "preact";
 import { FC, useCallback } from "react";
 import { useForm, FormProvider, useController } from "react-hook-form";
 import "./style.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,8 +34,11 @@
 
         /* Module Resolution Options */
         "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-        // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-        // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+        "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+          "react": ["./node_modules/preact/compat/"],
+          "react-dom": ["./node_modules/preact/compat/"]
+        },
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                       /* List of folders to include type definitions from. */
         // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
Main thing:

- Setting `--jsx react-jsx` is invalid. If you take a look at Microbundle's docs, `--jsx` sets the JSX pragma, not the transform method. What you've done is try to replace `h('h1', null, 'Hello World')` with `react-jsx('h1', null, 'Hello World')`. This doesn't work. What you wanted was the `--jsxImportSource` flag.
  - Even if you had though, you'd still have some amount of weirdness. While you would've told Microbundle what to use, you haven't told Typescript. It also needs to be aware. Because of your `tsconfig.json`, it thought you were still using the classic JSX transform, and using the `h` pragma, hence why you would get errors if you removed the `h` import.

Side Notes:
- Setting the `paths` in `tsconfig.json` ensures your types are correct, else you can get type mismatches or issues if React's types can't be found. This isn't the case here as `@types/react` is installed due to `enzyme`, I believe, but just something to be aware of. We document this on our site: https://preactjs.com/guide/v10/typescript#typescript-preactcompat-configuration 
- Would very much recommend against using the `preact/compat` alias yourself. It's creating layers of indirection in your code for no real benefit. Aliasing is great, as it allows you to make "changes" (so to speak) in external code that you don't have access to but relying on that for your own code is a bit of a smell, IMO. It can potentially create headaches, such as needing `@types/react` to be installed or aliased, as I mention above and did in this PR. Just another potential point of issues.
  - ```diff
    -import { h, JSX } from "preact";
    -import { FC, useCallback } from "react";
    +import { h, JSX, FunctionalComponent } from "preact";
    +import { useCallback } from "preact/hooks";
    ```
- You don't want to be using `FC` (it's been discouraged for years now, it's poor type and has a bunch of issues) nor should you really specify `JSX.Element`, but definitely don't do both.